### PR TITLE
Fix for Long Load times on load and zone flying

### DIFF
--- a/Carbonite.Quests/NxQuest.lua
+++ b/Carbonite.Quests/NxQuest.lua
@@ -5706,6 +5706,7 @@ function Nx.Quest:ShowUIPanel (frame)
 		end
 		self:LightHeadedAttach (frame)
 	else
+		Nx.Quest.List:Refresh()
 		self.IsOpen = true
 		local win = self.List.Win
 		if win and not GameMenuFrame:IsShown() then
@@ -6558,7 +6559,7 @@ function Nx.Quest.List:OnQuestUpdate (event, ...)
 			Nx.Quest.OldMap = oldmap
 			Nx.Quest:MapChanged()
 			
-			self:Refresh()
+--			self:Refresh() --killed this, makes load time really long
 		end
 	elseif event == "QUEST_PROGRESS" then
 		local auto = Nx.qdb.profile.Quest.AutoTurnIn


### PR DESCRIPTION
I hope this fixes the load time issue, that started after the fix for the quest detail sync.  Moved to the log display section, so that it only runs when someone views the carbonite quest log.