### PR TITLE
Watch Window cleanup and Quest Log fix

### DIFF
--- a/Carbonite.Quests/NxQuest.lua
+++ b/Carbonite.Quests/NxQuest.lua
@@ -9385,8 +9385,10 @@ function Nx.Quest.Watch:UpdateList()
 								local lnOffset = -1
 								for ln = 1, 31 do
 									local obj = quest and quest["Objectives"]
-									if obj then
+									if obj and (obj ~= "?" or obj ~= "nil") then
 										obj = quest and quest["Objectives"][ln]
+									else
+										break
 									end
 									if not obj or ln > lbNum then
 										break

--- a/Carbonite.Quests/NxQuest.lua
+++ b/Carbonite.Quests/NxQuest.lua
@@ -10108,9 +10108,11 @@ function Nx.Quest:TrackOnMap (qId, qObj, useEnd, target, skipSame)
 			questObj = useEnd and quest["End"] or quest["Start"]
 			name, zone, loc = Quest:UnpackSE (questObj)
 		else
-			questObj = quest["Objectives"][qObj]
-			if questObj and questObj[1] then
-				name, zone, loc = Nx.Quest:UnpackObjectiveNew (questObj[1])
+			if quest["Objectives"][qObj] ~= nil then
+				questObj = quest["Objectives"][qObj]
+				if questObj and questObj[1] then
+					name, zone, loc = Nx.Quest:UnpackObjectiveNew (questObj[1])
+				end
 			end
 		end
 

--- a/Carbonite.Quests/NxQuest.lua
+++ b/Carbonite.Quests/NxQuest.lua
@@ -10108,7 +10108,7 @@ function Nx.Quest:TrackOnMap (qId, qObj, useEnd, target, skipSame)
 			questObj = useEnd and quest["End"] or quest["Start"]
 			name, zone, loc = Quest:UnpackSE (questObj)
 		else
-			if quest["Objectives"][qObj] ~= nil then
+			if quest["Objectives"] ~= nil then
 				questObj = quest["Objectives"][qObj]
 				if questObj and questObj[1] then
 					name, zone, loc = Nx.Quest:UnpackObjectiveNew (questObj[1])

--- a/Carbonite.Quests/NxQuest.lua
+++ b/Carbonite.Quests/NxQuest.lua
@@ -6892,13 +6892,13 @@ function Nx.Quest.List:Update()
 
 						for ln = 1, num do
 
-							--[[zone = nil
+							zone = nil
 
 							local obj = quest and quest["Objectives"]
 
 							if obj then
 								desc, zone, loc = Nx.Quest:UnpackObjectiveNew (obj[n])
-							end]] -- Just use blizzard
+							end
 							desc, typ, done = GetQuestLogLeaderBoard (ln, qn)
 							--[[if ln <= num then
 								

--- a/Carbonite.Quests/NxQuest.lua
+++ b/Carbonite.Quests/NxQuest.lua
@@ -6890,17 +6890,18 @@ function Nx.Quest.List:Update()
 						local desc, typ, done
 						local zone, loc
 
-						for ln = 1, 15 do
+						for ln = 1, num do
 
-							zone = nil
+							--[[zone = nil
 
 							local obj = quest and quest["Objectives"]
 
 							if obj then
 								desc, zone, loc = Nx.Quest:UnpackObjectiveNew (obj[n])
-							end
-							if ln <= num then
-								desc, typ, done = GetQuestLogLeaderBoard (ln, qn)
+							end]] -- Just use blizzard
+							desc, typ, done = GetQuestLogLeaderBoard (ln, qn)
+							--[[if ln <= num then
+								
 								desc = desc or "?"	--V4
 
 							else
@@ -6910,7 +6911,7 @@ function Nx.Quest.List:Update()
 
 								done = false
 							end
-							if not desc then desc = "?" end
+							if not desc then desc = "?" end]]
 							color = done and "|cff5f5f6f" or "|cff9f9faf"
 							str = format ("     %s%s", color, desc)
 

--- a/Carbonite.Quests/NxQuest.lua
+++ b/Carbonite.Quests/NxQuest.lua
@@ -69,7 +69,7 @@ local defaults = {
 			HCheckCompleted = false,
 			maxLoadLevel = false,
 			LevelsToLoad = 10,
-			MapQuestGiversHighLevel = 100,
+			MapQuestGiversHighLevel = 110,
 			MapQuestGiversLowLevel = 1,
 			MapShowWatchAreas = true,
 			MapWatchAreaAlpha = "1|1|1|.4",
@@ -1660,7 +1660,7 @@ local function QuestOptions ()
 							name = L["Level Threshold"],
 							desc = L["Levels under player level to load quest data on reload"],
 							min = 1,
-							max = 100,
+							max = 110,
 							step = 1,
 							bigStep = 1,
 							get = function()

--- a/Carbonite.Quests/NxQuest.lua
+++ b/Carbonite.Quests/NxQuest.lua
@@ -9388,7 +9388,7 @@ function Nx.Quest.Watch:UpdateList()
 									if obj then
 										obj = quest and quest["Objectives"][ln]
 									end
-									if not obj and ln > lbNum then
+									if not obj or ln > lbNum then
 										break
 									end
 									zone = nil


### PR DESCRIPTION
Removed the not in database from the watch window, and also fixed the log so that show objective doesn't fill the screen with nil or ?.  If a person clicks on an objective on the log, that is not in the database, the code fix catches it, and does not error out. 