### PR TITLE
Remover rank arg as it does not exist in Blizzard anymore

### DIFF
--- a/Carbonite/Carbonite.lua
+++ b/Carbonite/Carbonite.lua
@@ -1183,7 +1183,7 @@ function Nx:OnUpdate_battlefield_score (event)
 	local show
 
 	for n = 1, scores do
-		local name, kbs, hks, deaths, honor, faction, rank, race, class, classCap, damDone, healDone = GetBattlefieldScore (n)
+		local name, kbs, hks, deaths, honor, faction, race, class, classCap, damDone, healDone = GetBattlefieldScore (n)
 		if name == plName then
 
 			honor = floor (honor)	--V4 returns weird fractions


### PR DESCRIPTION
From line 742 WorldStateFrame.lua

name, killingBlows, honorableKills, deaths, honorGained, faction, race, class, classToken, damageDone, healingDone, bgRating, ratingChange, preMatchMMR, mmrChange, talentSpec, prestige = GetBattlefieldScore(index);

Was removed in Build 13164 (4.0.1)
https://www.townlong-yak.com/framexml/4.0.1/WorldStateFrame.lua/diff
Line 689