### PR TITLE
Changed to eliminate taint

### DIFF
--- a/Carbonite/NxMap.lua
+++ b/Carbonite/NxMap.lua
@@ -4617,7 +4617,7 @@ function Nx.Map:Update (elapsed)
 	local poiNum = GetNumMapLandmarks()
 	for i = 1, poiNum do
 		-- type, name, desc, txIndex, pX, pY = C_WorldMap.GetMapLandmarkInfo (i)
-		type, name, desc, txIndex, pX, pY, mapLinkID, inBattleMap, graveyardID, areaID, poiID, isObjectIcon, atlasIcon, displayAsBanner = C_WorldMap.GetMapLandmarkInfo (i)		
+		local type, name, desc, txIndex, pX, pY, mapLinkID, inBattleMap, graveyardID, areaID, poiID, isObjectIcon, atlasIcon, displayAsBanner = C_WorldMap.GetMapLandmarkInfo(i);
 		Nx.prtCtrl ("LandMs %s, %s, %s, %s, %s, %s, %s, %s, %s", i, poiID, txIndex or '-', name, type, isObjectIcon, atlasIcon, displayAsBanner, WorldMap_IsSpecialPOI(poiID))
 		if atlasIcon or (pX and txIndex ~= 0) then		-- WotLK has 0 index POIs for named locations
 
@@ -5107,7 +5107,7 @@ function Nx.Map:ScanContinents()
 
 		for n = 1, poiNum do
 			-- type, name, desc, txIndex, pX, pY = C_WorldMap.GetMapLandmarkInfo (n)
-			type, name, desc, txIndex, pX, pY = GetMapLandmarkInfo (n)
+			local type, name, desc, txIndex, pX, pY = C_WorldMap.GetMapLandmarkInfo(n);
 				
 			if pX and name and not hideT[txIndex] then
 


### PR DESCRIPTION
Was getting a ton of taint from these, made changes based on reading current live on https://www.townlong-yak.com/ and made theses changes that have stopped the taint..  Had been getting pages of this repeating over and over again...

4/24 15:24:34.203  Global variable desc tainted by Carbonite - Interface\AddOns\Carbonite\NxMap.lua:4620 Update()
4/24 15:24:34.203      Interface\AddOns\Carbonite\NxMap.lua:3764
4/24 15:24:34.203  Global variable displayAsBanner tainted by Carbonite - Interface\AddOns\Carbonite\NxMap.lua:4620 Update()
4/24 15:24:34.203      Interface\AddOns\Carbonite\NxMap.lua:3764
4/24 15:24:34.203  Global variable atlasIcon tainted by Carbonite - Interface\AddOns\Carbonite\NxMap.lua:4620 Update()
4/24 15:24:34.203      Interface\AddOns\Carbonite\NxMap.lua:3764
4/24 15:24:34.203  Global variable isObjectIcon tainted by Carbonite - Interface\AddOns\Carbonite\NxMap.lua:4620 Update()
4/24 15:24:34.203      Interface\AddOns\Carbonite\NxMap.lua:3764
4/24 15:24:34.203  Global variable poiID tainted by Carbonite - Interface\AddOns\Carbonite\NxMap.lua:4620 Update()
4/24 15:24:34.203      Interface\AddOns\Carbonite\NxMap.lua:3764
4/24 15:24:34.203  Global variable areaID tainted by Carbonite - Interface\AddOns\Carbonite\NxMap.lua:4620 Update()
4/24 15:24:34.203      Interface\AddOns\Carbonite\NxMap.lua:3764
4/24 15:24:34.203  Global variable graveyardID tainted by Carbonite - Interface\AddOns\Carbonite\NxMap.lua:4620 Update()
4/24 15:24:34.203      Interface\AddOns\Carbonite\NxMap.lua:3764
4/24 15:24:34.203  Global variable inBattleMap tainted by Carbonite - Interface\AddOns\Carbonite\NxMap.lua:4620 Update()
4/24 15:24:34.203      Interface\AddOns\Carbonite\NxMap.lua:3764
4/24 15:24:34.203  Global variable mapLinkID tainted by Carbonite - Interface\AddOns\Carbonite\NxMap.lua:4620 Update()
4/24 15:24:34.203      Interface\AddOns\Carbonite\NxMap.lua:3764
4/24 15:24:34.203  Global variable desc tainted by Carbonite - Interface\AddOns\Carbonite\NxMap.lua:4620 Update()
4/24 15:24:34.203      Interface\AddOns\Carbonite\NxMap.lua:3764
4/24 15:24:34.203  Global variable displayAsBanner tainted by Carbonite - Interface\AddOns\Carbonite\NxMap.lua:4620 Update()
4/24 15:24:34.203      Interface\AddOns\Carbonite\NxMap.lua:3764
4/24 15:24:34.203  Global variable atlasIcon tainted by Carbonite - Interface\AddOns\Carbonite\NxMap.lua:4620 Update()
4/24 15:24:34.203      Interface\AddOns\Carbonite\NxMap.lua:3764
4/24 15:24:34.203  Global variable isObjectIcon tainted by Carbonite - Interface\AddOns\Carbonite\NxMap.lua:4620 Update()
4/24 15:24:34.203      Interface\AddOns\Carbonite\NxMap.lua:3764
4/24 15:24:34.203  Global variable poiID tainted by Carbonite - Interface\AddOns\Carbonite\NxMap.lua:4620 Update()
4/24 15:24:34.203      Interface\AddOns\Carbonite\NxMap.lua:3764
4/24 15:24:34.203  Global variable areaID tainted by Carbonite - Interface\AddOns\Carbonite\NxMap.lua:4620 Update()
4/24 15:24:34.203      Interface\AddOns\Carbonite\NxMap.lua:3764
4/24 15:24:34.203  Global variable graveyardID tainted by Carbonite - Interface\AddOns\Carbonite\NxMap.lua:4620 Update()
4/24 15:24:34.203      Interface\AddOns\Carbonite\NxMap.lua:3764
4/24 15:24:34.203  Global variable inBattleMap tainted by Carbonite - Interface\AddOns\Carbonite\NxMap.lua:4620 Update()
4/24 15:24:34.203      Interface\AddOns\Carbonite\NxMap.lua:3764
4/24 15:24:34.203  Global variable mapLinkID tainted by Carbonite - Interface\AddOns\Carbonite\NxMap.lua:4620 Update()
4/24 15:24:34.203      Interface\AddOns\Carbonite\NxMap.lua:3764
4/24 15:24:34.203  Global variable desc tainted by Carbonite - Interface\AddOns\Carbonite\NxMap.lua:4620 Update()
4/24 15:24:34.203      Interface\AddOns\Carbonite\NxMap.lua:3764