### PR TITLE
Attemt at fix for #128

### DIFF
--- a/NxMap.lua
+++ b/NxMap.lua
@@ -1,4 +1,4 @@
-﻿---------------------------------------------------------------------------------------
+---------------------------------------------------------------------------------------
 -- NxMap - Map code
 -- Copyright 2007-2012 Carbon Based Creations, LLC
 ---------------------------------------------------------------------------------------
@@ -5480,7 +5480,7 @@ function Nx.Map:UpdateGroup (plX, plY)
 			if UnitIsDeadOrGhost (unit) then
 				h = 0
 			end
-			local m = UnitHealthMax (unit)
+			local m = UnitHealthMax ("player")
 			local per = min (h / m, 1)			-- Can overflow?
 
 			if per > 0 then
@@ -5644,8 +5644,8 @@ function Nx.Map:UpdateGroup (plX, plY)
 					end
 				end
 --PAIDE!
-				local lvl = UnitLevel (unit)
-				local qStr = Nx.Com:GetPlyrQStr (name)
+				local lvl = UnitLevel ("player");
+				local qStr = Nx.Com:GetPlyrQStr ("name");
 
 				if raid then
 					local name, rank, grp = GetRaidRosterInfo (i)


### PR DESCRIPTION
(*temporary) = "Steeloak"

(*temporary) = 0             <----   Shows correct player level now

(*temporary) = "Druid"

(*temporary) = -nan(ind)  <----   And this error appears to be gone..

(*temporary) = 74.505504505495
(*temporary) = 15.115995115995
(*temporary) = ""
(*temporary) = ""
(*temporary) = ""