### PR TITLE
Don't leak 150 frames per zone change.  

### DIFF
--- a/NxMap.lua
+++ b/NxMap.lua
@@ -4191,12 +4191,19 @@ function Nx.Map:UpdateWorld()
 	
 	local texturesIDs = C_Map.GetMapArtLayerTextures(mapId, 1)
 	
-	for i = 1, numtiles do
+	if not self.textureLoadFrame then
 		local f = CreateFrame('frame', 'TestIfTextureExists')
 		local tx = f:CreateTexture()
 		tx:SetPoint('TOPLEFT', WorldFrame)
 		f:SetAllPoints(tx)
 		f:SetAlpha(0)
+		self.textureLoadFrame = f
+		self.textureLoadTx = tx
+	end
+	local f = self.textureLoadFrame
+	local tx = self.textureLoadTx
+
+	for i = 1, numtiles do
 		f:SetScript('OnSizeChanged', function(self, width, height)
 			local size = format('%.0f%.0f', width, height)
 			if size == '11' then -- doesnt exists

--- a/NxMap.lua
+++ b/NxMap.lua
@@ -4191,30 +4191,8 @@ function Nx.Map:UpdateWorld()
 	
 	local texturesIDs = C_Map.GetMapArtLayerTextures(mapId, 1)
 	
-	if not self.textureLoadFrame then
-		local f = CreateFrame('frame', 'TestIfTextureExists')
-		local tx = f:CreateTexture()
-		tx:SetPoint('TOPLEFT', WorldFrame)
-		f:SetAllPoints(tx)
-		f:SetAlpha(0)
-		self.textureLoadFrame = f
-		self.textureLoadTx = tx
-	end
-	local f = self.textureLoadFrame
-	local tx = self.textureLoadTx
-
 	for i = 1, numtiles do
-		f:SetScript('OnSizeChanged', function(self, width, height)
-			local size = format('%.0f%.0f', width, height)
-			if size == '11' then -- doesnt exists
-				self.tileFrm.texture:SetTexture (texturesIDs[i])
-			else
-				self.tileFrm.texture:SetTexture (texPath..texName..i)
-			end
-		end)
-		f.tileFrm = self.TileFrms[i]
-		tx:SetTexture(texPath..texName..i)
-		tx:SetSize(0,0)
+		self.TileFrms[i].texture:SetTexture (texturesIDs[i])
 	end
 end
 


### PR DESCRIPTION
Current master causes massive cpu and memory waste each zone swap.  I was losing upwards of 5 fps per zone change, cumulative, after this new texture loading method was added due to the insane number of frames created.
Initially I changed to just reuse frames, but even that causes a modest and continual degradation over not creating any at all, so I swapped to doing that.  I've not seen areas yet where the texture id based loading isn't working.