### PR TITLE
support wowhead (TomTom) waypoints

### DIFF
--- a/NxMap.lua
+++ b/NxMap.lua
@@ -10365,7 +10365,7 @@ function Nx.Map:ParseTargetStr (str)
 
 	local mid = Nx.Map.UpdateMapID
 
-	if zone then		
+	if zone then
 		mid = nil
 		local cont = 0
 		local curmid = Nx.Map:GetCurrentMapAreaID()				
@@ -10379,15 +10379,19 @@ function Nx.Map:ParseTargetStr (str)
 		end
 		
 		for id, zonedesc in pairs (Nx.Zones) do
-			local name = strlower (string.gsub (zonedesc, "|.*", ""))
-			if name == zone or string.sub (name, 1, #zone) == zone then
-				if (cont > 0) and Nx.Map.MapWorldInfo[id].Cont == cont then
-					mid = id
-				elseif (cont == 0) then
-					if not mid or math.abs(mid - curmid) > math.abs(mid - id) then
+			if "#" .. id == zone then
+				mid = id
+			else
+				local name = strlower (string.gsub (zonedesc, "|.*", ""))
+				if name == zone or string.sub (name, 1, #zone) == zone then
+					if (cont > 0) and Nx.Map.MapWorldInfo[id].Cont == cont then
 						mid = id
-					end				
-				end			
+					elseif (cont == 0) then
+						if not mid or math.abs(mid - curmid) > math.abs(mid - id) then
+							mid = id
+						end				
+					end			
+				end
 			end
 		end
 


### PR DESCRIPTION
Hi,

I added support for waypoints in the TomTom format found all over wowhead.com
f.e. in this guide https://www.wowhead.com/news/mote-of-naszuro-new-battle-pet-available-to-all-players-due-to-evoker-legendary-333050

These always have the format f.e.

```
/way #2023 61.23 64.36 Windsong Rise
```

which was currently not supported by Carbonite and was quite bugging me :)

The new code to detect "#[id]" as zone id should be backwards-compatible with other (?) formats.