### PR TITLE
Fixes #284 and error from 11.1.5

### DIFF
--- a/NxMap.lua
+++ b/NxMap.lua
@@ -3279,7 +3279,9 @@ WorldMapFrame:HookScript("OnShow", function()
 			if WorldMapFrame:IsShown() then
 				Nx.Map:RestoreBlizzBountyMap()	
 				local map = Nx.Map:GetMap (1)
-				map:DetachWorldMap()
+				if map then
+					map:DetachWorldMap()
+				end
 			end
 		else
 			-- DugisGuide FIX

--- a/NxUI.lua
+++ b/NxUI.lua
@@ -29,7 +29,7 @@ function Nx:UIInit()
     local qc = {}
     self.QualityColors = qc
 
-    for n = 0, 10 do
+    for n = 0, 8 do
         local r, g, b, hex = C_Item.GetItemQualityColor(n)
         qc[n] = hex
     end


### PR DESCRIPTION
I added nil check in NxMap.lua fixing issue [#284](https://github.com/mikepauer/Carbonite/issues/284) for game versions 11.0.7 and 11.1.0+ (hopefully not skipping/messing with any features).

And fixed error for game version 11.1.5(PTR) in NXUI.lua, by stopping the loop at 8 instead of 10, as C_Item.GetItemQualityColor() currently contains only 9 (0-8) values.